### PR TITLE
Propose fix a couple of typos and ignore emacs backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,5 @@ cython_debug/
 .pypirc
 
 **/.DS_Store
+# Emacs backup files
+*~

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ pip install 'pytuq[dev]'
     $ git clone git@github.com:sandialabs/pytuq.git
     $ cd pytuq
 ```
-2. (Optional) To take advantage of the neural network surrogate model capabilites in PyTUQ, use the following command to install PyTUQ's optional dependencies:
+2. (Optional) To take advantage of the neural network surrogate model capabilities in PyTUQ, use the following command to install PyTUQ's optional dependencies:
 ```
     $ pip install -r requirements.txt
 ```
@@ -82,7 +82,7 @@ $ pip install 'pytuq[dev]'
 ## License
 Distributed under BSD 3-Clause License. See `LICENSE.txt` for more information.
 
-## Acknowledgements
-This work is supported by the Scientific Discovery through Advanced Computing (SciDAC) Program under the Office of Science at the U.S. Department of Energy. 
+## Acknowledgments
+This work is supported by the Scientific Discovery through Advanced Computing (SciDAC) Program under the Office of Science at the U.S. Department of Energy.
 
 Sandia National Laboratories is a multimission laboratory managed and operated by National Technology & Engineering Solutions of Sandia, LLC, a wholly owned subsidiary of Honeywell International Inc., for the U.S. Department of Energy’s National Nuclear Security Administration under contract DE-NA0003525.

--- a/contributed/dakota_examples/pce/surrogate.py
+++ b/contributed/dakota_examples/pce/surrogate.py
@@ -29,7 +29,7 @@ class Pytuq:
 
     def __init__(self, params=None):
 
-        print("Pytuq surrogate class constructer...")
+        print("Pytuq surrogate class constructor...")
         self.pce = PCE(dim, order, 'LU')
 
 
@@ -78,7 +78,7 @@ class Polynomial:
 
     def __init__(self, params=None):
 
-        print("python Polynomial Surrogate class constructer...")
+        print("python Polynomial Surrogate class constructor...")
         self.coeffs = None
         if params is not None:
             self.params = params

--- a/docs/misc/installation.rst
+++ b/docs/misc/installation.rst
@@ -21,17 +21,17 @@ To install from source for the most recent stable release of PyTUQ, start up a P
 
 Then, install the PyTUQ package and its dependencies via 'pip'.
 
-To install just the primary PyTUQ dependencies, use the following command: 
+To install just the primary PyTUQ dependencies, use the following command:
 
 .. code-block:: console
 
     $ pip install .
 
-To take advantage of the neural network surrogate model capabilites in PyTUQ, use the following commands to install PyTUQ along with its optional dependencies:
+To take advantage of the neural network surrogate model capabilities in PyTUQ, use the following commands to install PyTUQ along with its optional dependencies:
 
 .. code-block:: console
 
-    $ pip install -r requirements.txt 
+    $ pip install -r requirements.txt
     $ pip install .
 
 If you don't have `pip`_ installed, this `Python installation guide`_ can guide


### PR DESCRIPTION
Propose fix a couple of typos and ignore emacs backup files.  Trim trailing whitespace.

Is this helpful?